### PR TITLE
Fix user context menu, and double-click

### DIFF
--- a/Data/Templates/newMessagePostedWithSender.mustache
+++ b/Data/Templates/newMessagePostedWithSender.mustache
@@ -6,14 +6,18 @@
   time="{{lineRenderTime}}">
 
 	<div class="nick">
-  	<span class="sender"
-  		ondblclick="Textual.nicknameDoubleClicked()"
-  		oncontextmenu="Textual.openStandardNicknameContextualMenu()"
-  		type="{{nicknameType}}"
-  		nick="{{nickname}}"
-  		{{#nicknameColorHashingEnabled}}
-  			colornumber="{{nicknameColorNumber}}"
-  		{{/nicknameColorHashingEnabled}}>{{formattedNickname}}</span>
+	  	<span class="sender"
+	  		ondblclick="Textual.nicknameDoubleClicked()"
+	  		oncontextmenu="Textual.openStandardNicknameContextualMenu()"
+	  		type="{{nicknameType}}"
+	  		nick="{{nickname}}"
+	  		nickname="{{nickname}}"
+	  		{{#nicknameColorHashingEnabled}}
+	  			colornumber="{{nicknameColorNumber}}"
+	  		{{/nicknameColorHashingEnabled}}
+	  	>
+	  			{{formattedNickname}}
+  		</span>
 	</div>
 		<div class="msg">
 {{#isRemoteMessage}}


### PR DESCRIPTION
When you interact with a username (for example, right-clicking to bring up a context menu, or double-click to do whatever action you have defined in your application preferences,) Textual looks for the "nickname" attribute of the DOM element to find the username it should work with.

Previously, Bonfire did not set this attribute correctly. This meant many user interactions were broken.

This commit fixes that by changing the newMessagePostedWithSender template to add a "nickname" attribute to the username <span> that detects double click and context menu events.
