### PR TITLE
Make install instructions a little more clear about what folder to install in

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See the information below on [Older Versions](#older) if you want to use this th
 * Expand Addons
 * Choose Installed Addons
 * Choose Open In Finder
+* Open the Styles folder
 * Clone the repository or install the ZIP
 
 ##### Cloning the repository
@@ -31,7 +32,6 @@ See the information below on [Older Versions](#older) if you want to use this th
 
 * Visit https://github.com/yyyc514/textual_bonfire_style
 * Click Download ZIP on the right side
-* Extract the zipfile into the Styles folder
 * Consider renaming the folder to remove the '-master' suffix
 
 Now go choose your shiny new theme inside Textual.  You're welcome.


### PR DESCRIPTION
This is really minor, but because I knew I was going to clone it and not install the ZIP, I didn't read the "Install the ZIP" section that has the info on what folder the theme goes into. 

It was easy enough to figure out though, but I thought I'd update the README with it.
